### PR TITLE
Modification proposal

### DIFF
--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -564,8 +564,8 @@ pub struct BlockStreamMetrics {
     pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Gauge,
     pub stopwatch: StopwatchMetrics,
-    pub subgraph_name: String, 
-    pub subgraph_version: String, 
+    pub subgraph_name: String, // Dynamic subgraphName field
+    pub subgraph_version: String, // Version of the subgraph
 }
 
 impl BlockStreamMetrics {
@@ -575,11 +575,8 @@ impl BlockStreamMetrics {
         network: String,
         shard: String,
         stopwatch: StopwatchMetrics,
-        subgraph_name: String, 
-        subgraph_version: String, 
+        subgraph_version: String,
     ) -> Self {
-        let subgraph_name = "Dynamic".to_string();
-        let subgraph_version = "0.0.4".to_string();
         let reverted_blocks = registry
             .new_deployment_gauge(
                 "deployment_reverted_blocks",
@@ -591,8 +588,8 @@ impl BlockStreamMetrics {
             String::from("deployment") => deployment_id.to_string(),
             String::from("network") => network,
             String::from("shard") => shard,
-            String::from("subgraph") => subgraph_name.clone(), 
-            String::from("version") => subgraph_version.clone(), 
+            // No subgraphName label here since it's dynamic
+            String::from("subgraph_version") => subgraph_version.clone(), 
 
         };
         let deployment_head = registry
@@ -614,9 +611,14 @@ impl BlockStreamMetrics {
             deployment_failed,
             reverted_blocks,
             stopwatch,
-            subgraph_name,
+            subgraph_name: String::new(),
             subgraph_version,
+            
         }
+    }
+    // Sets or updates the subgraph name dynamically
+    pub fn set_subgraph_name(&mut self, subgraph_name: String){
+        self.subgraph_name =subgraph_name;
     }
 }
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -564,6 +564,8 @@ pub struct BlockStreamMetrics {
     pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Gauge,
     pub stopwatch: StopwatchMetrics,
+    pub subgraph_name: String, 
+    pub subgraph_version: String, 
 }
 
 impl BlockStreamMetrics {
@@ -573,7 +575,11 @@ impl BlockStreamMetrics {
         network: String,
         shard: String,
         stopwatch: StopwatchMetrics,
+        subgraph_name: String, 
+        subgraph_version: String, 
     ) -> Self {
+        let subgraph_name = "Dynamic".to_string();
+        let subgraph_version = "0.0.4".to_string();
         let reverted_blocks = registry
             .new_deployment_gauge(
                 "deployment_reverted_blocks",
@@ -584,7 +590,10 @@ impl BlockStreamMetrics {
         let labels = labels! {
             String::from("deployment") => deployment_id.to_string(),
             String::from("network") => network,
-            String::from("shard") => shard
+            String::from("shard") => shard,
+            String::from("subgraph") => subgraph_name.clone(), 
+            String::from("version") => subgraph_version.clone(), 
+
         };
         let deployment_head = registry
             .new_gauge(
@@ -605,6 +614,8 @@ impl BlockStreamMetrics {
             deployment_failed,
             reverted_blocks,
             stopwatch,
+            subgraph_name,
+            subgraph_version,
         }
     }
 }


### PR DESCRIPTION
In the modified code, the `subgraph_name` field is initialized as an empty string within the `new` function, and then its value can be set dynamically later using the `set_subgraph_name` method. This approach allows for flexibility in assigning the subgraph name after the `BlockStreamMetrics` instance has been created. It's useful when the subgraph name is not known at the time of instantiation but becomes available later during program execution.