### PR TITLE
Dev

### DIFF
--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -564,8 +564,8 @@ pub struct BlockStreamMetrics {
     pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Gauge,
     pub stopwatch: StopwatchMetrics,
-    pub subgraph_name: String, 
-    pub subgraph_version: String, 
+    pub subgraph_name: String, // Dynamic subgraphName field
+    pub subgraph_version: String, // Version of the subgraph
 }
 
 impl BlockStreamMetrics {
@@ -575,11 +575,8 @@ impl BlockStreamMetrics {
         network: String,
         shard: String,
         stopwatch: StopwatchMetrics,
-        subgraph_name: String, 
-        subgraph_version: String, 
+        subgraph_version: String,
     ) -> Self {
-        let subgraph_name = "Dynamic".to_string();
-        let subgraph_version = "0.0.4".to_string();
         let reverted_blocks = registry
             .new_deployment_gauge(
                 "deployment_reverted_blocks",
@@ -591,8 +588,8 @@ impl BlockStreamMetrics {
             String::from("deployment") => deployment_id.to_string(),
             String::from("network") => network,
             String::from("shard") => shard,
-            String::from("subgraph") => subgraph_name.clone(), 
-            String::from("version") => subgraph_version.clone(), 
+            // No subgraphName label here since it's dynamic
+            String::from("subgraph_version") => subgraph_version.clone(), 
 
         };
         let deployment_head = registry
@@ -614,9 +611,14 @@ impl BlockStreamMetrics {
             deployment_failed,
             reverted_blocks,
             stopwatch,
-            subgraph_name,
+            subgraph_name: String::new(),
             subgraph_version,
+            
         }
+    }
+    // Sets or updates the subgraph name dynamically
+    pub fn set_subgraph_name(&mut self, subgraph_name: String){
+        self.subgraph_name =subgraph_name;
     }
 }
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -564,8 +564,8 @@ pub struct BlockStreamMetrics {
     pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Gauge,
     pub stopwatch: StopwatchMetrics,
-    pub subgraph_name: String, // Dynamic subgraphName field
-    pub subgraph_version: String, // Version of the subgraph
+    pub subgraph_name: String,
+    pub subgraph_version: String,
 }
 
 impl BlockStreamMetrics {
@@ -576,6 +576,7 @@ impl BlockStreamMetrics {
         shard: String,
         stopwatch: StopwatchMetrics,
         subgraph_version: String,
+        subgraph_name: String,
     ) -> Self {
         let reverted_blocks = registry
             .new_deployment_gauge(
@@ -588,9 +589,8 @@ impl BlockStreamMetrics {
             String::from("deployment") => deployment_id.to_string(),
             String::from("network") => network,
             String::from("shard") => shard,
-            // No subgraphName label here since it's dynamic
-            String::from("subgraph_version") => subgraph_version.clone(), 
-
+            String::from("subgraphName") => subgraph_name.clone(),
+            String::from("subgraphVersion") => subgraph_version.clone(),
         };
         let deployment_head = registry
             .new_gauge(
@@ -603,7 +603,7 @@ impl BlockStreamMetrics {
             .new_gauge(
                 "deployment_failed",
                 "Boolean gauge to indicate whether the deployment has failed (1 == failed)",
-                labels,
+                labels.clone(),
             )
             .expect("failed to create `deployment_failed` gauge");
         Self {
@@ -611,14 +611,9 @@ impl BlockStreamMetrics {
             deployment_failed,
             reverted_blocks,
             stopwatch,
-            subgraph_name: String::new(),
+            subgraph_name,
             subgraph_version,
-            
         }
-    }
-    // Sets or updates the subgraph name dynamically
-    pub fn set_subgraph_name(&mut self, subgraph_name: String){
-        self.subgraph_name =subgraph_name;
     }
 }
 

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -564,6 +564,8 @@ pub struct BlockStreamMetrics {
     pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Gauge,
     pub stopwatch: StopwatchMetrics,
+    pub subgraph_name: String, 
+    pub subgraph_version: String, 
 }
 
 impl BlockStreamMetrics {
@@ -573,7 +575,11 @@ impl BlockStreamMetrics {
         network: String,
         shard: String,
         stopwatch: StopwatchMetrics,
+        subgraph_name: String, 
+        subgraph_version: String, 
     ) -> Self {
+        let subgraph_name = "Dynamic".to_string();
+        let subgraph_version = "0.0.4".to_string();
         let reverted_blocks = registry
             .new_deployment_gauge(
                 "deployment_reverted_blocks",
@@ -584,7 +590,10 @@ impl BlockStreamMetrics {
         let labels = labels! {
             String::from("deployment") => deployment_id.to_string(),
             String::from("network") => network,
-            String::from("shard") => shard
+            String::from("shard") => shard,
+            String::from("subgraph") => subgraph_name.clone(), 
+            String::from("version") => subgraph_version.clone(), 
+
         };
         let deployment_head = registry
             .new_gauge(
@@ -605,6 +614,8 @@ impl BlockStreamMetrics {
             deployment_failed,
             reverted_blocks,
             stopwatch,
+            subgraph_name,
+            subgraph_version,
         }
     }
 }


### PR DESCRIPTION
Changes Made:

Added subgraphName and subgraphVersion labels to the deployment_head metric in the BlockStreamMetrics struct.
Updated the new constructor method to include these labels when creating the deployment_head and deployment_failed gauges.